### PR TITLE
DD-1586 Added truncate-notifications with commandline input parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-dataverse-cli</artifactId>
-    <version>0.4.2-SNAPSHOT</version>
+    <version>0.4.1-SNAPSHOT</version>
 
     <name>DD Dataverse CLI</name>
     <url>https://github.com/DANS-KNAW/dd-dataverse-cli</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-dataverse-cli</artifactId>
-    <version>0.4.1-SNAPSHOT</version>
+    <version>0.4.2-SNAPSHOT</version>
 
     <name>DD Dataverse CLI</name>
     <url>https://github.com/DANS-KNAW/dd-dataverse-cli</url>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,14 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/assembly/dist/cfg/example-config.yml
+++ b/src/main/assembly/dist/cfg/example-config.yml
@@ -4,9 +4,9 @@ api:
 
 db:
   host: localhost
-  database: "dvndb";
-  user: "dvnuser";
-  password: "dvnsecret";
+  database: "dvndb"
+  user: "dvnuser"
+  password: "dvnsecret"
 
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging

--- a/src/main/assembly/dist/cfg/example-config.yml
+++ b/src/main/assembly/dist/cfg/example-config.yml
@@ -1,4 +1,4 @@
-dataverse:
+api:
   baseUrl: "http://localhost:8080"
   apiKey: "your-api-token"
 

--- a/src/main/assembly/dist/cfg/example-config.yml
+++ b/src/main/assembly/dist/cfg/example-config.yml
@@ -2,6 +2,12 @@ dataverse:
   baseUrl: "http://localhost:8080"
   apiKey: "your-api-token"
 
+db:
+  host: localhost
+  database: "dvndb";
+  user: "dvnuser";
+  password: "dvnsecret";
+
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging
 #

--- a/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
+++ b/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
@@ -58,6 +58,7 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
     public void configureCommandLine(CommandLine commandLine, DdDataverseCliConfig config) {
         log.debug("Building Dataverse client");
         var dataverseClient = config.getDataverse().build();
+        var databaseConfig = config.getDb();
         commandLine.addSubcommand(new CommandLine(new CollectionCmd(dataverseClient))
                 .addSubcommand(new CollectionAssignRole())
                 .addSubcommand(new CollectionCreateDataset())
@@ -75,7 +76,7 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
             .addSubcommand(new CommandLine(new DatasetCmd(dataverseClient))
                 .addSubcommand(new DeleteDraft())
             )
-            .addSubcommand(new CommandLine(new NotificationTruncate()));
+            .addSubcommand(new CommandLine(new NotificationTruncate(databaseConfig)));
         log.debug("Configuring command line");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
+++ b/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
@@ -59,7 +59,7 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
     @Override
     public void configureCommandLine(CommandLine commandLine, DdDataverseCliConfig config) {
         log.debug("Building Dataverse client");
-        var dataverseClient = config.getDataverse().build();
+        var dataverseClient = config.getApi().build();
         var databaseConfig = config.getDb();
         var database = new Database(databaseConfig);
         

--- a/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
+++ b/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
@@ -33,6 +33,7 @@ import nl.knaw.dans.dvcli.command.CollectionSetMetadataBlocksRoot;
 import nl.knaw.dans.dvcli.command.CollectionView;
 import nl.knaw.dans.dvcli.command.DatasetCmd;
 import nl.knaw.dans.dvcli.command.DeleteDraft;
+import nl.knaw.dans.dvcli.command.NotificationTruncate;
 import nl.knaw.dans.dvcli.config.DdDataverseCliConfig;
 import nl.knaw.dans.lib.util.AbstractCommandLineApp;
 import nl.knaw.dans.lib.util.PicocliVersionProvider;
@@ -73,7 +74,8 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
                 .addSubcommand(new CollectionView()))
             .addSubcommand(new CommandLine(new DatasetCmd(dataverseClient))
                 .addSubcommand(new DeleteDraft())
-            );
+            )
+            .addSubcommand(new CommandLine(new NotificationTruncate()));
         log.debug("Configuring command line");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
+++ b/src/main/java/nl/knaw/dans/dvcli/DdDataverseCli.java
@@ -17,6 +17,7 @@
 package nl.knaw.dans.dvcli;
 
 import lombok.extern.slf4j.Slf4j;
+import nl.knaw.dans.dvcli.action.Database;
 import nl.knaw.dans.dvcli.command.CollectionAssignRole;
 import nl.knaw.dans.dvcli.command.CollectionCmd;
 import nl.knaw.dans.dvcli.command.CollectionCreateDataset;
@@ -35,6 +36,7 @@ import nl.knaw.dans.dvcli.command.DatasetCmd;
 import nl.knaw.dans.dvcli.command.DeleteDraft;
 import nl.knaw.dans.dvcli.command.NotificationTruncate;
 import nl.knaw.dans.dvcli.config.DdDataverseCliConfig;
+import nl.knaw.dans.lib.dataverse.DataverseClient;
 import nl.knaw.dans.lib.util.AbstractCommandLineApp;
 import nl.knaw.dans.lib.util.PicocliVersionProvider;
 import picocli.CommandLine;
@@ -59,6 +61,8 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
         log.debug("Building Dataverse client");
         var dataverseClient = config.getDataverse().build();
         var databaseConfig = config.getDb();
+        var database = new Database(databaseConfig);
+        
         commandLine.addSubcommand(new CommandLine(new CollectionCmd(dataverseClient))
                 .addSubcommand(new CollectionAssignRole())
                 .addSubcommand(new CollectionCreateDataset())
@@ -76,7 +80,7 @@ public class DdDataverseCli extends AbstractCommandLineApp<DdDataverseCliConfig>
             .addSubcommand(new CommandLine(new DatasetCmd(dataverseClient))
                 .addSubcommand(new DeleteDraft())
             )
-            .addSubcommand(new CommandLine(new NotificationTruncate(databaseConfig)));
+            .addSubcommand(new CommandLine(new NotificationTruncate(database)));
         log.debug("Configuring command line");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -91,9 +91,7 @@ public class Database {
             List<String> columnNames = new ArrayList<String>();
             for (int i = 1; i <= numColumns; i++) {
                 columnNames.add(rs.getMetaData().getColumnName(i));
-                //System.out.print(rs.getMetaData().getColumnName(i) + " ");
             }
-            //System.out.println("");
 
             // make it the first row, for simplicity, a bit like with a csv file
             rows.add(columnNames);
@@ -102,10 +100,8 @@ public class Database {
                 List<String> row = new ArrayList<String>();
                 for (int i = 1; i <= numColumns; i++) {
                     row.add(rs.getString(i));
-                    //System.out.print(rs.getString(i) + " ");
                 }
                 rows.add(row);
-                //System.out.println("");
             }
             
             // cleanup
@@ -116,5 +112,17 @@ public class Database {
         }
         
         return rows;
+    }
+    
+    public int update(String sql) {
+        int rowCount = 0;
+        try {
+            Statement stmt = connection.createStatement();
+            rowCount = stmt.executeUpdate( sql );
+            stmt.close();
+        } catch (SQLException e) {
+            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
+        }
+        return rowCount;
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -56,7 +56,7 @@ public class Database {
     public void connect() throws ClassNotFoundException, SQLException {
             Class.forName("org.postgresql.Driver");
             if (connection == null) {
-                log.info("Starting connecting to database");
+                log.debug("Starting connecting to database");
                 connection = DriverManager
                         .getConnection("jdbc:postgresql://" + host + ":" + port + "/" + database,
                                 user,
@@ -68,7 +68,7 @@ public class Database {
     public void close() {
         try {
             if (connection != null) {
-                log.info("Close connection to database");
+                log.debug("Close connection to database");
                 connection.close();
             }
         } catch (SQLException e) {
@@ -83,7 +83,7 @@ public class Database {
     }
     
     public List<List<String>> query(String sql, Boolean startResultWithColumnNames) throws SQLException {
-        log.info("Qerying database with: " + sql);
+        log.debug("Qerying database with: " + sql);
         
         Statement stmt = connection.createStatement();
         ResultSet rs = stmt.executeQuery( sql );
@@ -120,7 +120,7 @@ public class Database {
     }
 
     public int update(String sql) throws SQLException {
-        log.info("Updating database with: " + sql);
+        log.debug("Updating database with: " + sql);
         int rowCount = 0;
 
         Statement stmt = connection.createStatement();

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvcli.action;
+
+import nl.knaw.dans.dvcli.config.DdDataverseDatabaseConfig;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Provides access to the Dataverse Database (Postgres).
+ * Some actions are not supported by the Dataverse API (yet) 
+ * and must be done by direct access to the database.
+ */
+public class Database {
+    
+    public Database(DdDataverseDatabaseConfig config) {
+        this.host = config.getHost();
+        this.database = config.getDatabase();
+        this.user = config.getUser();
+        this.password = config.getPassword();
+    }
+    
+    Connection connection = null;
+
+    String port = "5432"; // Fixed port for Postgres
+    // TODO should come from config
+    String host = "localhost";
+    String database = "dvndb";
+    String user = "dvnapp";
+    String password = "secret";
+    
+    public void connect() {
+        try {
+            if (connection == null) {
+                connection = DriverManager
+                        .getConnection("jdbc:postgresql://" + host + ":" + port + "/" + database,
+                                user,
+                                password);
+            }
+            if (connection != null) {
+                System.out.println("Connected to the database!");
+            } else {
+                System.out.println("Failed to make connection!");
+            }
+        } catch (SQLException e) {
+            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
+        }
+    }
+    
+    public void close() {
+        try {
+            if (connection != null) {
+                connection.close();
+                connection = null;
+            }
+        } catch (SQLException e) {
+            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -46,14 +46,13 @@ public class Database {
     Connection connection = null;
 
     String port = "5432"; // Fixed port for Postgres
-    // TODO should come from config
+    
     String host;
     String database;
     String user;
     String password;
     
-    public void connect() {
-        try {
+    public void connect() throws ClassNotFoundException, SQLException {
             Class.forName("org.postgresql.Driver");
             if (connection == null) {
                 connection = DriverManager
@@ -61,9 +60,7 @@ public class Database {
                                 user,
                                 password);
             }
-        } catch (Exception e) {
-            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
-        }
+
     }
     
     public void close() {
@@ -78,58 +75,51 @@ public class Database {
         }
     }
 
-    public List<List<String>> query(String sql) {
+    public List<List<String>> query(String sql) throws SQLException {
         return query(sql, false);
     }
     
-    public List<List<String>> query(String sql, Boolean startResultWithColumnNames) {
+    public List<List<String>> query(String sql, Boolean startResultWithColumnNames) throws SQLException {
         List<List<String>> rows = new ArrayList<>();
-        try {
-            Statement stmt = connection.createStatement();
-            ResultSet rs = stmt.executeQuery( sql );
-            
-            // extract data from result set
-            // get column names
-            int numColumns = rs.getMetaData().getColumnCount();
-            
-            if (startResultWithColumnNames) {
-                List<String> columnNames = new ArrayList<String>();
-                for (int i = 1; i <= numColumns; i++) {
-                    columnNames.add(rs.getMetaData().getColumnName(i));
-                }
-                
-                // make it the first row, for simplicity, a bit like with a csv file
-                rows.add(columnNames);
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery( sql );
+        
+        // extract data from result set
+        
+        // get column names
+        int numColumns = rs.getMetaData().getColumnCount();
+        if (startResultWithColumnNames) {
+            List<String> columnNames = new ArrayList<String>();
+            for (int i = 1; i <= numColumns; i++) {
+                columnNames.add(rs.getMetaData().getColumnName(i));
             }
-            
-            // get the data rows
-            while (rs.next()) {
-                List<String> row = new ArrayList<String>();
-                for (int i = 1; i <= numColumns; i++) {
-                    row.add(rs.getString(i));
-                }
-                rows.add(row);
-            }
-            
-            // cleanup
-            rs.close();
-            stmt.close();
-        } catch (SQLException e) {
-            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
+            // make it the first row, for simplicity, a bit like with a csv file
+            rows.add(columnNames);
         }
+        
+        // get the data rows
+        while (rs.next()) {
+            List<String> row = new ArrayList<String>();
+            for (int i = 1; i <= numColumns; i++) {
+                row.add(rs.getString(i));
+            }
+            rows.add(row);
+        }
+        
+        // cleanup
+        rs.close();
+        stmt.close();
         
         return rows;
     }
     
-    public int update(String sql) {
+    public int update(String sql) throws SQLException {
         int rowCount = 0;
-        try {
-            Statement stmt = connection.createStatement();
-            rowCount = stmt.executeUpdate( sql );
-            stmt.close();
-        } catch (SQLException e) {
-            System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
-        }
+
+        Statement stmt = connection.createStatement();
+        rowCount = stmt.executeUpdate( sql );
+        stmt.close();
+
         return rowCount;
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -61,11 +61,6 @@ public class Database {
                                 user,
                                 password);
             }
-            if (connection != null) {
-                System.out.println("Connected to the database!");
-            } else {
-                System.out.println("Failed to make connection!");
-            }
         } catch (Exception e) {
             System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
         }
@@ -75,10 +70,11 @@ public class Database {
         try {
             if (connection != null) {
                 connection.close();
-                connection = null;
             }
         } catch (SQLException e) {
             System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
+        } finally {
+            connection = null;
         }
     }
 

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -79,7 +79,8 @@ public class Database {
         }
     }
     
-    public void query(String sql) {
+    public List<List<String>> query(String sql) {
+        List<List<String>> rows = new ArrayList<>();
         try {
             Statement stmt = connection.createStatement();
             ResultSet rs = stmt.executeQuery( sql );
@@ -90,29 +91,30 @@ public class Database {
             List<String> columnNames = new ArrayList<String>();
             for (int i = 1; i <= numColumns; i++) {
                 columnNames.add(rs.getMetaData().getColumnName(i));
-                System.out.print(rs.getMetaData().getColumnName(i) + " ");
+                //System.out.print(rs.getMetaData().getColumnName(i) + " ");
             }
-            System.out.println("");
-            // get the rows
-            List<List<String>> rows = new ArrayList<>();
+            //System.out.println("");
+
+            // make it the first row, for simplicity, a bit like with a csv file
+            rows.add(columnNames);
+            // get the data rows
             while (rs.next()) {
                 List<String> row = new ArrayList<String>();
                 for (int i = 1; i <= numColumns; i++) {
                     row.add(rs.getString(i));
-                    System.out.print(rs.getString(i) + " ");
+                    //System.out.print(rs.getString(i) + " ");
                 }
                 rows.add(row);
-                System.out.println("");
+                //System.out.println("");
             }
             
             // cleanup
             rs.close();
             stmt.close();
-
-            // store results (columnNames and rows) in csv ?
-            
         } catch (SQLException e) {
             System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
         }
+        
+        return rows;
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -85,14 +85,12 @@ public class Database {
     public List<List<String>> query(String sql, Boolean startResultWithColumnNames) throws SQLException {
         log.debug("Qerying database with: " + sql);
         
-        Statement stmt = connection.createStatement();
-        ResultSet rs = stmt.executeQuery( sql );
-        List<List<String>> rows = extractResult(rs, startResultWithColumnNames);
-        
-        rs.close();
-        stmt.close();
-        
-        return rows;
+        try (
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(sql)
+        ) {
+            return extractResult(rs, startResultWithColumnNames);
+        }
     }
 
     List<List<String>> extractResult(ResultSet rs, Boolean startResultWithColumnNames) throws SQLException {
@@ -121,12 +119,9 @@ public class Database {
 
     public int update(String sql) throws SQLException {
         log.debug("Updating database with: " + sql);
-        int rowCount = 0;
 
-        Statement stmt = connection.createStatement();
-        rowCount = stmt.executeUpdate( sql );
-        stmt.close();
-
-        return rowCount;
+        try (Statement stmt = connection.createStatement()) {
+            return stmt.executeUpdate(sql);
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -30,7 +30,7 @@ import java.util.List;
  * Provides access to the Dataverse Database (Postgres).
  * Some actions are not supported by the Dataverse API (yet) 
  * and must be done by direct access to the database.
- * 
+ * <p> 
  * Note that the sql input strings are not filtered in any way, 
  * so don't put user input in there!
  */
@@ -83,7 +83,7 @@ public class Database {
     }
     
     public List<List<String>> query(String sql, Boolean startResultWithColumnNames) throws SQLException {
-        log.debug("Qerying database with: " + sql);
+        log.debug("Querying database with: {}", sql);
         
         try (
             Statement stmt = connection.createStatement();
@@ -118,7 +118,7 @@ public class Database {
     }
 
     public int update(String sql) throws SQLException {
-        log.debug("Updating database with: " + sql);
+        log.debug("Updating database with: {}", sql);
 
         try (Statement stmt = connection.createStatement()) {
             return stmt.executeUpdate(sql);

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -44,10 +44,10 @@ public class Database {
 
     String port = "5432"; // Fixed port for Postgres
     // TODO should come from config
-    String host = "localhost";
-    String database = "dvndb";
-    String user = "dvnuser";
-    String password = "dvnsecret";
+    String host;
+    String database;
+    String user;
+    String password;
     
     public void connect() {
         try {
@@ -86,8 +86,9 @@ public class Database {
             
             // extract data from result set
             // get column names
+            int numColumns = rs.getMetaData().getColumnCount();
             List<String> columnNames = new ArrayList<String>();
-            for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+            for (int i = 1; i <= numColumns; i++) {
                 columnNames.add(rs.getMetaData().getColumnName(i));
                 System.out.print(rs.getMetaData().getColumnName(i) + " ");
             }
@@ -96,7 +97,7 @@ public class Database {
             List<List<String>> rows = new ArrayList<>();
             while (rs.next()) {
                 List<String> row = new ArrayList<String>();
-                for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
+                for (int i = 1; i <= numColumns; i++) {
                     row.add(rs.getString(i));
                     System.out.print(rs.getString(i) + " ");
                 }
@@ -109,6 +110,7 @@ public class Database {
             stmt.close();
 
             // store results (columnNames and rows) in csv ?
+            
         } catch (SQLException e) {
             System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
         }

--- a/src/main/java/nl/knaw/dans/dvcli/action/Database.java
+++ b/src/main/java/nl/knaw/dans/dvcli/action/Database.java
@@ -30,6 +30,9 @@ import java.util.List;
  * Provides access to the Dataverse Database (Postgres).
  * Some actions are not supported by the Dataverse API (yet) 
  * and must be done by direct access to the database.
+ * 
+ * Note that the sql input strings are not filtered in any way, 
+ * so don't put user input in there!
  */
 public class Database {
     
@@ -78,8 +81,12 @@ public class Database {
             System.err.println( "Database error: " + e.getClass().getName() + " " + e.getMessage() );
         }
     }
-    
+
     public List<List<String>> query(String sql) {
+        return query(sql, false);
+    }
+    
+    public List<List<String>> query(String sql, Boolean startResultWithColumnNames) {
         List<List<String>> rows = new ArrayList<>();
         try {
             Statement stmt = connection.createStatement();
@@ -88,13 +95,17 @@ public class Database {
             // extract data from result set
             // get column names
             int numColumns = rs.getMetaData().getColumnCount();
-            List<String> columnNames = new ArrayList<String>();
-            for (int i = 1; i <= numColumns; i++) {
-                columnNames.add(rs.getMetaData().getColumnName(i));
+            
+            if (startResultWithColumnNames) {
+                List<String> columnNames = new ArrayList<String>();
+                for (int i = 1; i <= numColumns; i++) {
+                    columnNames.add(rs.getMetaData().getColumnName(i));
+                }
+                
+                // make it the first row, for simplicity, a bit like with a csv file
+                rows.add(columnNames);
             }
-
-            // make it the first row, for simplicity, a bit like with a csv file
-            rows.add(columnNames);
+            
             // get the data rows
             while (rs.next()) {
                 List<String> row = new ArrayList<String>();

--- a/src/main/java/nl/knaw/dans/dvcli/command/AbstractCmd.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/AbstractCmd.java
@@ -35,5 +35,5 @@ public abstract class AbstractCmd implements Callable<Integer> {
         }
     }
 
-    public abstract void doCall() throws IOException, DataverseException;
+    public abstract void doCall() throws Exception, DataverseException;
 }

--- a/src/main/java/nl/knaw/dans/dvcli/command/AbstractCmd.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/AbstractCmd.java
@@ -35,5 +35,5 @@ public abstract class AbstractCmd implements Callable<Integer> {
         }
     }
 
-    public abstract void doCall() throws Exception, DataverseException;
+    public abstract void doCall() throws Exception;
 }

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -49,7 +49,7 @@ public class NotificationTruncate extends AbstractCmd {
 
     static class UserOptions {
         @CommandLine.Option(names = { "--user" }, required = true, 
-                description = "The user whose notifications to truncate.")
+                description = "The user database id (a number) whose notifications to truncate.")
         int user; // a number, preventing accidental SQL injection
         // This id is visible for 'superusers' in the Dataverse Dashboard
         

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -62,6 +62,5 @@ public class NotificationTruncate extends AbstractCmd {
         // do someting with the database
         db.query("SELECT * FROM usernotification;");
         db.close();
-        throw new UnsupportedOperationException("Not yet implemented.");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -22,11 +22,9 @@ import nl.knaw.dans.dvcli.action.ConsoleReport;
 import nl.knaw.dans.dvcli.action.Database;
 import nl.knaw.dans.dvcli.action.Pair;
 import nl.knaw.dans.dvcli.action.ThrowingFunction;
-import nl.knaw.dans.dvcli.config.DdDataverseDatabaseConfig;
 
 import picocli.CommandLine;
 
-import javax.validation.constraints.Positive;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -43,6 +41,10 @@ public class NotificationTruncate extends AbstractCmd {
         this.db = database;
     }
 
+    private static final long DEFAULT_DELAY = 10L; // 10 ms, database should be able to handle this
+    
+    @CommandLine.Option(names = { "-d", "--delay" }, description = "Delay in milliseconds between requests to the server (default: ${DEFAULT-VALUE}).", defaultValue = "" + DEFAULT_DELAY)
+    protected long delay = DEFAULT_DELAY;
     
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     UserOptions users;
@@ -67,7 +69,6 @@ public class NotificationTruncate extends AbstractCmd {
 
     protected <NotificationTruncateParams> BatchProcessor.BatchProcessorBuilder<NotificationTruncate.NotificationTruncateParams, String> paramsBatchProcessorBuilder() throws IOException {
         return BatchProcessor.<NotificationTruncate.NotificationTruncateParams, String> builder();
-
     }
     
     private static class NotificationTruncateAction implements ThrowingFunction<NotificationTruncate.NotificationTruncateParams, String, Exception> {
@@ -107,7 +108,7 @@ public class NotificationTruncate extends AbstractCmd {
             paramsBatchProcessorBuilder()
                     .labeledItems(getItems())
                     .action(new NotificationTruncate.NotificationTruncateAction())
-                    .delay(10L) // 10 ms, database should be able to handle this
+                    .delay(delay)
                     .report(new ConsoleReport<>())
                     .build()
                     .process();

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -87,6 +87,7 @@ public class NotificationTruncate extends AbstractCmd {
             
             // Actually delete the notifications
             try {
+                log.info("Deleting notifications for user with id " + notificationTruncateParams.userId);
                 int rowCount = notificationTruncateParams.db.update(String.format("DELETE FROM usernotification WHERE user_id = '%d' AND id NOT IN (SELECT id FROM usernotification WHERE user_id = '%d' ORDER BY senddate DESC LIMIT %d);",
                         notificationTruncateParams.userId, notificationTruncateParams.userId,
                         notificationTruncateParams.numberOfRecordsToKeep));
@@ -110,9 +111,12 @@ public class NotificationTruncate extends AbstractCmd {
         //db = new Database(dbCfg);
         db.connect();
         
+        log.info("Starting batch processing");
+        
         paramsBatchProcessorBuilder()
                 .labeledItems(getItems())
                 .action(new NotificationTruncate.NotificationTruncateAction())
+                .delay(10L) // 10 ms, database should be able to handle this
                 .report(new ConsoleReport<>())
                 .build()
                 .process();

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvcli.command;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "truncate-notifications",
+        mixinStandardHelpOptions = true,
+        description = "Remove user notifications but keep up to a specified amount.")
+public class NotificationTruncate extends AbstractCmd {
+    // dataverse truncate-notifications {--user <uid>|--all-users } <number-of-records-to-keep>
+
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    UserOptions users;
+
+    static class UserOptions {
+        @CommandLine.Option(names = { "--user" }, required = true, description = "The user whose notifications to truncate.")
+        private String user;
+        @CommandLine.Option(names = { "--all-users" }, required = true, description = "Truncate notifications for all users.")
+        private boolean allUser;
+    }
+    
+    @CommandLine.Parameters(index = "0", paramLabel = "number-of-records-to-keep", description = "The number of notifications to keep.")
+    private int numberOfRecordsToKeep;
+    
+    @Override
+    public void doCall() {
+        // show commandline input
+        System.out.println("Truncating notifications...");
+        System.out.println("Number of records to keep: " + numberOfRecordsToKeep);
+        System.out.println("User: " + (users.allUser ? "all users" : users.user));
+        
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+}

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -26,6 +26,7 @@ import nl.knaw.dans.dvcli.config.DdDataverseDatabaseConfig;
 
 import picocli.CommandLine;
 
+import javax.validation.constraints.Positive;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ public class NotificationTruncate extends AbstractCmd {
     
     @CommandLine.Parameters(index = "0", paramLabel = "number-of-records-to-keep", 
             description = "The number of notification records to keep.")
+    @Positive
     private int numberOfRecordsToKeep;
     
     private record NotificationTruncateParams(Database db, int userId, int numberOfRecordsToKeep) {

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -58,9 +58,10 @@ public class NotificationTruncate extends AbstractCmd {
         
         // Connect to database
         Database db = new Database(dbcfg);
-        //db.connect();
+        db.connect();
         // do someting with the database
-        //db.close();
+        db.query("SELECT * FROM usernotification;");
+        db.close();
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -67,7 +67,7 @@ public class NotificationTruncate extends AbstractCmd {
     private record NotificationTruncateParams(Database db, int userId, int numberOfRecordsToKeep) {
     }
 
-    protected <NotificationTruncateParams> BatchProcessor.BatchProcessorBuilder<NotificationTruncate.NotificationTruncateParams, String> paramsBatchProcessorBuilder() throws IOException {
+    private BatchProcessor.BatchProcessorBuilder<NotificationTruncate.NotificationTruncateParams, String> paramsBatchProcessorBuilder() throws IOException {
         return BatchProcessor.<NotificationTruncate.NotificationTruncateParams, String> builder();
     }
     
@@ -85,7 +85,7 @@ public class NotificationTruncate extends AbstractCmd {
             
             // Actually delete the notifications
             try {
-                log.info("Deleting notifications for user with id " + notificationTruncateParams.userId);
+                log.info("Deleting notifications for user with id {}", notificationTruncateParams.userId);
                 int rowCount = notificationTruncateParams.db.update(String.format("DELETE FROM usernotification WHERE user_id = '%d' AND id NOT IN (SELECT id FROM usernotification WHERE user_id = '%d' ORDER BY senddate DESC LIMIT %d);",
                         notificationTruncateParams.userId, notificationTruncateParams.userId,
                         notificationTruncateParams.numberOfRecordsToKeep));
@@ -117,7 +117,7 @@ public class NotificationTruncate extends AbstractCmd {
         }
     }
     
-    protected List<Pair<String, NotificationTruncateParams>> getItems() throws Exception {
+    List<Pair<String, NotificationTruncateParams>> getItems() throws Exception {
         List<Pair<String, NotificationTruncateParams>> items = new ArrayList<>();
         try {
             if (users.allUsers) {

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -60,7 +60,6 @@ public class NotificationTruncate extends AbstractCmd {
     
     @CommandLine.Parameters(index = "0", paramLabel = "number-of-records-to-keep", 
             description = "The number of notification records to keep.")
-    @Positive
     private int numberOfRecordsToKeep;
     
     private record NotificationTruncateParams(Database db, int userId, int numberOfRecordsToKeep) {

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -37,7 +37,6 @@ import java.util.List;
         sortOptions = false)
 @Slf4j
 public class NotificationTruncate extends AbstractCmd {
-    //DdDataverseDatabaseConfig dbCfg;
     protected Database db;
     public NotificationTruncate(@NonNull Database database) {
         this.db = database;
@@ -51,7 +50,7 @@ public class NotificationTruncate extends AbstractCmd {
         @CommandLine.Option(names = { "--user" }, required = true, 
                 description = "The user whose notifications to truncate.")
         int user; // a number, preventing accidental SQL injection
-        // This id is visible in the Dataverse Dashboard for 'superusers' 
+        // This id is visible for 'superusers' in the Dataverse Dashboard
         
         @CommandLine.Option(names = { "--all-users" }, required = true, 
                 description = "Truncate notifications for all users.")
@@ -61,23 +60,20 @@ public class NotificationTruncate extends AbstractCmd {
     @CommandLine.Parameters(index = "0", paramLabel = "number-of-records-to-keep", 
             description = "The number of notification records to keep.")
     private int numberOfRecordsToKeep;
-
-//    @CommandLine.Option(names = { "-d", "--delay" }, description = "Delay in milliseconds between requests to the server (default: ${DEFAULT-VALUE}).", defaultValue = "" + DEFAULT_DELAY)
-//    protected long delay;
     
     private record NotificationTruncateParams(Database db, int userId, int numberOfRecordsToKeep) {
     }
 
     protected <NotificationTruncateParams> BatchProcessor.BatchProcessorBuilder<NotificationTruncate.NotificationTruncateParams, String> paramsBatchProcessorBuilder() throws IOException {
         return BatchProcessor.<NotificationTruncate.NotificationTruncateParams, String> builder();
-                //.delay(delay);
+
     }
     
     private static class NotificationTruncateAction implements ThrowingFunction<NotificationTruncate.NotificationTruncateParams, String, Exception> {
 
         @Override
         public String apply(NotificationTruncateParams notificationTruncateParams) throws Exception {
-            // Dry-run for now, show what will be deleted
+            // Dry-run; show what will be deleted
             //List<List<String>> results = notificationTruncateParams.db.query(String.format("SELECT * FROM usernotification WHERE user_id = '%d' AND id NOT IN (SELECT id FROM usernotification WHERE user_id = '%d' ORDER BY senddate DESC LIMIT %d);", 
             //        notificationTruncateParams.userId, notificationTruncateParams.userId, 
             //        notificationTruncateParams.numberOfRecordsToKeep), true
@@ -102,16 +98,12 @@ public class NotificationTruncate extends AbstractCmd {
     public void doCall() throws Exception {
         // validate input
         if (numberOfRecordsToKeep < 0) {
-            //System.err.println("Number of records to keep must be a positive integer, now it was \" + numberOfRecordsToKeep + \".\"");
-            //return; // or should we throw an exception or exit(2) ?
             throw new Exception("Number of records to keep must be a positive integer, now it was " + numberOfRecordsToKeep + ".");
         }
         
         // Connect to database
         //db = new Database(dbCfg);
         db.connect();
-        
-        log.info("Starting batch processing");
         
         paramsBatchProcessorBuilder()
                 .labeledItems(getItems())
@@ -152,7 +144,6 @@ public class NotificationTruncate extends AbstractCmd {
         for (List<String> row : results) {
             users.add(Integer.parseInt(row.get(0)));
         }
-        System.out.println("Number of users found for notification truncation: " + users.size());
         return users;
     }
     

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.dvcli.command;
 
+import nl.knaw.dans.dvcli.action.Database;
+import nl.knaw.dans.dvcli.config.DdDataverseDatabaseConfig;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "truncate-notifications",
@@ -22,6 +24,11 @@ import picocli.CommandLine;
         description = "Remove user notifications but keep up to a specified amount.")
 public class NotificationTruncate extends AbstractCmd {
     // dataverse truncate-notifications {--user <uid>|--all-users } <number-of-records-to-keep>
+
+    DdDataverseDatabaseConfig dbcfg;
+    public NotificationTruncate(DdDataverseDatabaseConfig dbcfg) {
+        this.dbcfg = dbcfg;
+    }
 
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     UserOptions users;
@@ -43,6 +50,17 @@ public class NotificationTruncate extends AbstractCmd {
         System.out.println("Number of records to keep: " + numberOfRecordsToKeep);
         System.out.println("User: " + (users.allUser ? "all users" : users.user));
         
+        // show database config
+        System.out.println("Database config - host: " + dbcfg.getHost());
+        System.out.println("Database config - database: " + dbcfg.getDatabase());
+        System.out.println("Database config - user: " + dbcfg.getUser());
+        System.out.println("Database config - password: " + dbcfg.getPassword());
+        
+        // Connect to database
+        Database db = new Database(dbcfg);
+        //db.connect();
+        // do someting with the database
+        //db.close();
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 }

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.dvcli.command;
 
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.dvcli.action.BatchProcessor;
 import nl.knaw.dans.dvcli.action.ConsoleReport;
@@ -36,12 +37,12 @@ import java.util.List;
         sortOptions = false)
 @Slf4j
 public class NotificationTruncate extends AbstractCmd {
-    DdDataverseDatabaseConfig dbCfg;
-    public NotificationTruncate(DdDataverseDatabaseConfig dbCfg) {
-        this.dbCfg = dbCfg;
+    //DdDataverseDatabaseConfig dbCfg;
+    protected Database db;
+    public NotificationTruncate(@NonNull Database database) {
+        this.db = database;
     }
 
-    protected Database db;
     
     @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     UserOptions users;
@@ -49,12 +50,12 @@ public class NotificationTruncate extends AbstractCmd {
     static class UserOptions {
         @CommandLine.Option(names = { "--user" }, required = true, 
                 description = "The user whose notifications to truncate.")
-        private int user; // a number, preventing accidental SQL injection
+        int user; // a number, preventing accidental SQL injection
         // This id is visible in the Dataverse Dashboard for 'superusers' 
         
         @CommandLine.Option(names = { "--all-users" }, required = true, 
                 description = "Truncate notifications for all users.")
-        private boolean allUsers;
+        boolean allUsers;
     }
     
     @CommandLine.Parameters(index = "0", paramLabel = "number-of-records-to-keep", 
@@ -106,7 +107,7 @@ public class NotificationTruncate extends AbstractCmd {
         }
         
         // Connect to database
-        db = new Database(dbCfg);
+        //db = new Database(dbCfg);
         db.connect();
         
         paramsBatchProcessorBuilder()

--- a/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
+++ b/src/main/java/nl/knaw/dans/dvcli/command/NotificationTruncate.java
@@ -103,19 +103,18 @@ public class NotificationTruncate extends AbstractCmd {
             throw new Exception("Number of records to keep must be a positive integer, now it was " + numberOfRecordsToKeep + ".");
         }
         
-        // Connect to database
-        //db = new Database(dbCfg);
         db.connect();
-        
-        paramsBatchProcessorBuilder()
-                .labeledItems(getItems())
-                .action(new NotificationTruncate.NotificationTruncateAction())
-                .delay(10L) // 10 ms, database should be able to handle this
-                .report(new ConsoleReport<>())
-                .build()
-                .process();
-
-        db.close(); // Not called if anny exception is thrown above!
+        try {
+            paramsBatchProcessorBuilder()
+                    .labeledItems(getItems())
+                    .action(new NotificationTruncate.NotificationTruncateAction())
+                    .delay(10L) // 10 ms, database should be able to handle this
+                    .report(new ConsoleReport<>())
+                    .build()
+                    .process();
+        } finally {
+            db.close();
+        }
     }
     
     protected List<Pair<String, NotificationTruncateParams>> getItems() throws Exception {

--- a/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseCliConfig.java
+++ b/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseCliConfig.java
@@ -25,7 +25,7 @@ import nl.knaw.dans.lib.util.DataverseClientFactory;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class DdDataverseCliConfig extends Configuration {
-    private DataverseClientFactory dataverse;
+    private DataverseClientFactory api;
     
     @NonNull
     private DdDataverseDatabaseConfig db = new DdDataverseDatabaseConfig();

--- a/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseDatabaseConfig.java
+++ b/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseDatabaseConfig.java
@@ -16,17 +16,23 @@
 
 package nl.knaw.dans.dvcli.config;
 
-import io.dropwizard.core.Configuration;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
-import nl.knaw.dans.lib.util.DataverseClientFactory;
+
+import javax.validation.constraints.NotEmpty;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class DdDataverseCliConfig extends Configuration {
-    private DataverseClientFactory dataverse;
+public class DdDataverseDatabaseConfig {
     
-    @NonNull
-    private DdDataverseDatabaseConfig db = new DdDataverseDatabaseConfig();
+    @NotEmpty
+    private String host = "localhost";
+    
+    @NotEmpty
+    private String database = "dvndb";
+    
+    @NotEmpty
+    private String user = "dvnapp";
+
+    @NotEmpty
+    private String password = "secret";
 }
+

--- a/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseDatabaseConfig.java
+++ b/src/main/java/nl/knaw/dans/dvcli/config/DdDataverseDatabaseConfig.java
@@ -30,9 +30,9 @@ public class DdDataverseDatabaseConfig {
     private String database = "dvndb";
     
     @NotEmpty
-    private String user = "dvnapp";
+    private String user = "dvnuser";
 
     @NotEmpty
-    private String password = "secret";
+    private String password = "dvnsecret";
 }
 

--- a/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
+++ b/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
@@ -37,11 +37,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class NotificationTruncateTest extends AbstractCapturingTest {
 
-    private final InputStream originalStdin = System.in;
-
     @Test
     public void doCall_with_wrong_database_connection_fails() throws Exception {
-        System.setIn(originalStdin);
 
         var database = Mockito.mock(Database.class);
         doThrow(new SQLException("test database fails to connect")).when(database).connect();
@@ -59,8 +56,6 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
 
     @Test
     public void doCall_with_negative_numberOfRecordsToKeep_fails() throws Exception {
-        System.setIn(originalStdin);
-
         var database = Mockito.mock(Database.class);
  
         var userOptions = new NotificationTruncate.UserOptions();
@@ -76,8 +71,6 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
     
     @Test
     public void doCall_with_several_users_to_truncate_notifications_works() throws Exception {
-        System.setIn(originalStdin);
-
         var database = Mockito.mock(Database.class);
         
         Mockito.doNothing().when(database).connect();

--- a/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
+++ b/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+
 public class NotificationTruncateTest extends AbstractCapturingTest {
 
     private final InputStream originalStdin = System.in;
@@ -99,8 +100,6 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
         
         assertThat(stderr.toString()).isEqualTo("1: OK. 2: OK. 3: OK. ");
         assertThat(stdout.toString()).isEqualTo("""
-            INFO  Starting batch processing
-            Number of users found for notification truncation: 3
             INFO  Starting batch processing
             INFO  Processing item 1 of 3
             INFO  Deleting notifications for user with id 1

--- a/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
+++ b/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
@@ -20,8 +20,6 @@ import nl.knaw.dans.dvcli.action.Database;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-
-import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.List;
 

--- a/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
+++ b/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
@@ -40,7 +40,7 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
     private final InputStream originalStdin = System.in;
 
     @Test
-    public void failWrongConnection () throws Exception {
+    public void doCall_with_wrong_database_connection_fails() throws Exception {
         System.setIn(originalStdin);
 
         var database = Mockito.mock(Database.class);
@@ -58,7 +58,7 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
     }
 
     @Test
-    public void testFailWrongNumberOfRecordsToKeep () throws Exception {
+    public void doCall_with_negative_numberOfRecordsToKeep_fails() throws Exception {
         System.setIn(originalStdin);
 
         var database = Mockito.mock(Database.class);
@@ -75,7 +75,7 @@ public class NotificationTruncateTest extends AbstractCapturingTest {
     }
     
     @Test
-    public void testAllUsers () throws Exception {
+    public void doCall_with_several_users_to_truncate_notifications_works() throws Exception {
         System.setIn(originalStdin);
 
         var database = Mockito.mock(Database.class);

--- a/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
+++ b/src/test/java/nl/knaw/dans/dvcli/command/NotificationTruncateTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.dvcli.command;
+
+import nl.knaw.dans.dvcli.AbstractCapturingTest;
+import nl.knaw.dans.dvcli.action.Database;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+import java.io.InputStream;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+
+public class NotificationTruncateTest extends AbstractCapturingTest {
+
+    private final InputStream originalStdin = System.in;
+
+    @Test
+    public void failWrongConnection () throws Exception {
+        System.setIn(originalStdin);
+
+        var database = Mockito.mock(Database.class);
+        //Mockito.when(database.connect()).thenThrow(new SQLException("test exception"));
+        doThrow(new SQLException("test database fails to connect")).when(database).connect();
+        
+        var userOptions = new NotificationTruncate.UserOptions();
+        userOptions.user = 13;
+        userOptions.allUsers = false;
+        
+        var cmd = getCmd(database, 1, userOptions);
+        
+        assertThatThrownBy(cmd::doCall)
+               .isInstanceOf(SQLException.class)
+               .hasMessage("test database fails to connect");
+
+        
+        //System.out.println("stdout: " + stdout.toString());
+        //System.out.println("stderr: " + stderr.toString());
+        //
+        // but nothing in the output
+    }
+
+    @Test
+    public void testFailWrongNumberOfRecordsToKeep () throws Exception {
+        System.setIn(originalStdin);
+
+        var database = Mockito.mock(Database.class);
+ 
+        var userOptions = new NotificationTruncate.UserOptions();
+        userOptions.user = 13;
+        userOptions.allUsers = false;
+
+        var cmd = getCmd(database, -1, userOptions);
+
+        assertThatThrownBy(cmd::doCall)
+                .isInstanceOf(Exception.class)
+                .hasMessage("Number of records to keep must be a positive integer, now it was -1.");
+    }
+    
+    private static NotificationTruncate getCmd(Database database, int numberOfRecordsToKeep, NotificationTruncate.UserOptions userOptions ) throws NoSuchFieldException, IllegalAccessException {
+        var cmd = new NotificationTruncate(database);
+
+        // set private fields with reflection
+        
+        var numberOfRecordsToKeepField = NotificationTruncate.class.getDeclaredField("numberOfRecordsToKeep");
+        numberOfRecordsToKeepField.setAccessible(true);
+        numberOfRecordsToKeepField.set(cmd, numberOfRecordsToKeep);
+
+        var usersField = NotificationTruncate.class.getDeclaredField("users");
+        usersField.setAccessible(true);
+        usersField.set(cmd, userOptions);
+        return cmd;
+    }
+     
+}

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -1,4 +1,4 @@
-dataverse:
+api:
   baseUrl: "http://dev.archaeology.datastations.nl:8080"
   apiKey: # fill in your API key here
   

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -1,7 +1,13 @@
 api:
   baseUrl: "http://dev.archaeology.datastations.nl:8080"
   apiKey: # fill in your API key here
-  
+
+db:
+  host: localhost
+  database: "dvndb"
+  user: "dvnuser"
+  password: "dvnsecret"
+
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging
 #


### PR DESCRIPTION
Fixes DD-1586

# Description of changes
Implement  `dataverse truncate-notifications {--user <uid>|--all-users } <number-of-records-to-keep>`


# How to test
Deploy the role on a fresh lifesciences dev box:
```
start-preprovisioned-box.py -s dev_lifesciences
deploy.py -m dd-dataverse-cli dev_lifesciences
```
Ssh into the box and run some commands and check the result.
Example:
```
[vagrant@lifesciences ~]$ dataverse truncate-notifications --user 123 100
123: OK. Deleted 0 record(s) for user with id 123
[vagrant@lifesciences ~]$ dataverse truncate-notifications --all-users 20
Number of users found for notification truncation: 0
[vagrant@lifesciences ~]$ dataverse truncate-notifications --user 3 2
3: OK. Deleted 1 record(s) for user with id 3
[vagrant@lifesciences ~]$ dataverse truncate-notifications --all-users 2
Number of users found for notification truncation: 2
1: OK. Deleted 3 record(s) for user with id 1
8: OK. Deleted 1 record(s) for user with id 8
```

# Related PRs
(Add links)
* https://github.com/DANS-KNAW/dans-core-systems/pull/62

# Notify
@DANS-KNAW/core-systems
