### PR TITLE
DD-1946: upgrade parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dd-dataverse-cli</artifactId>
@@ -35,7 +35,6 @@
 
     <properties>
         <main-class>nl.knaw.dans.dvcli.DdDataverseCli</main-class>
-        <picocli.version>4.7.5</picocli.version> <!-- TODO: move to parent -->
         <command-name>dataverse</command-name>
     </properties>
 
@@ -80,7 +79,6 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0</version>
     </parent>
 
     <artifactId>dd-dataverse-cli</artifactId>


### PR DESCRIPTION
Fixes DD-

# Description of changes


# How to test

Tried `start.sh dataset 'doi:10.5072/DAR/...' publish`
on `v. 6.7.1 build DANS-DataStation-PATCH-7`
and was surprised to see it working because parent/pom uses dans-dataverse-client-lib v1.4.0 and DatasetPublicationResult was changed in v1.4.2

update: it does not do getData() but getEnvelopeAsString()

# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/core-systems
